### PR TITLE
Addition of fns for pk signing with detached messages.

### DIFF
--- a/pgsodium--0.0.1.sql
+++ b/pgsodium--0.0.1.sql
@@ -100,6 +100,16 @@ RETURNS text
 AS '$libdir/pgsodium', 'pgsodium_crypto_sign_open'
 LANGUAGE C IMMUTABLE STRICT;
 
+CREATE OR REPLACE FUNCTION crypto_sign_detached(message bytea, key bytea)
+RETURNS bytea
+AS '$libdir/pgsodium', 'pgsodium_crypto_sign_detached'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION crypto_sign_verify_detached(sig bytea, message bytea, key bytea)
+RETURNS boolean
+AS '$libdir/pgsodium', 'pgsodium_crypto_sign_verify_detached'
+LANGUAGE C IMMUTABLE STRICT;
+
 CREATE OR REPLACE FUNCTION crypto_pwhash_saltgen()
 RETURNS bytea
 AS '$libdir/pgsodium', 'pgsodium_crypto_pwhash_saltgen'

--- a/src/pgsodium.h
+++ b/src/pgsodium.h
@@ -78,5 +78,7 @@ Datum pgsodium_crypto_box_seal_open(PG_FUNCTION_ARGS);
 Datum pgsodium_crypto_sign_keypair(PG_FUNCTION_ARGS);
 Datum pgsodium_crypto_sign(PG_FUNCTION_ARGS);
 Datum pgsodium_crypto_sign_open(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_detached(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_verify_detached(PG_FUNCTION_ARGS);
 
 #endif /* PGSODIUM_H */

--- a/test.sql
+++ b/test.sql
@@ -13,7 +13,7 @@ CREATE EXTENSION pgtap;
 CREATE EXTENSION pgsodium;
 
 BEGIN;
-SELECT plan(20);
+SELECT plan(22);
 
 SELECT lives_ok($$SELECT randombytes_random()$$, 'randombytes_random');
 SELECT lives_ok($$SELECT randombytes_uniform(10)$$, 'randombytes_uniform');
@@ -75,6 +75,21 @@ SELECT crypto_sign('bob is your uncle', :'sign_secret') signed \gset
 SELECT is(crypto_sign_open(:'signed', :'sign_public'),
           'bob is your uncle', 'crypto_sign/open');
 
+-- MM Start Tests for crypto_sign_detached.  You may want to move
+-- these if you want to preserve the previous test numbering
+
+-- We will sign our previously generated sealed box
+SELECT crypto_sign_detached(:'sealed', :'sign_secret') detached \gset
+
+SELECT is(crypto_sign_verify_detached(:'detached', :'sealed', :'sign_public'),
+          true, 'crypto_sign_detached/verify');
+
+SELECT is(crypto_sign_verify_detached(:'detached', 'xyzzy'::bytea, :'sign_public'),
+          false, 'crypto_sign_detached/verify (incorrect message)');
+
+-- MM End
+
+
 SELECT lives_ok($$SELECT crypto_pwhash_saltgen()$$, 'crypto_pwhash_saltgen');
 
 SELECT is(crypto_pwhash('Correct Horse Battery Staple', '\xccfe2b51d426f88f6f8f18c24635616b'),
@@ -84,6 +99,7 @@ SELECT is(crypto_pwhash('Correct Horse Battery Staple', '\xccfe2b51d426f88f6f8f1
 SELECT ok(crypto_pwhash_str_verify(crypto_pwhash_str('Correct Horse Battery Staple'),
           'Correct Horse Battery Staple'),
           'crypto_pwhash_str_verify');
+
 
 -- test relocatable schema
 


### PR DESCRIPTION
`crypto_sign_(verify_)detached` from @marcmunro.