### PR TITLE
Multipart

### DIFF
--- a/pgsodium--1.0.0--1.1.0.sql
+++ b/pgsodium--1.0.0--1.1.0.sql
@@ -64,3 +64,92 @@ AS '$libdir/pgsodium', 'pgsodium_randombytes_buf_deterministic'
 LANGUAGE C IMMUTABLE STRICT;
 
     
+-- Marc's hacks follow
+
+CREATE OR REPLACE FUNCTION crypto_sign_init()
+RETURNS bytea
+AS '$libdir/pgsodium', 'pgsodium_crypto_sign_init'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION crypto_sign_update(state bytea, message bytea)
+RETURNS bytea
+AS '$libdir/pgsodium', 'pgsodium_crypto_sign_update'
+LANGUAGE C IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION crypto_sign_final_create(state bytea, key bytea)
+RETURNS bytea
+AS '$libdir/pgsodium', 'pgsodium_crypto_sign_final_create'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE FUNCTION crypto_sign_final_verify(state bytea, signature bytea, key bytea)
+RETURNS boolean
+AS '$libdir/pgsodium', 'pgsodium_crypto_sign_final_verify'
+LANGUAGE C IMMUTABLE STRICT;
+
+CREATE OR REPLACE
+FUNCTION crypto_sign_update_agg1(state bytea, message bytea)
+  RETURNS bytea
+AS
+$$
+  SELECT crypto_sign_update(COALESCE(state, crypto_sign_init()), message);
+$$
+LANGUAGE SQL IMMUTABLE;
+
+COMMENT ON FUNCTION crypto_sign_update_agg1(bytea, bytea) IS
+'Internal helper function for crypto_sign_update_agg(bytea).  This
+initializes state if it has not already been initialized.';
+
+CREATE OR REPLACE
+FUNCTION crypto_sign_update_agg2(cur_state bytea,
+                                 initial_state bytea,
+				 message bytea)
+  RETURNS bytea
+as
+$$
+  SELECT crypto_sign_update(
+             COALESCE(cur_state, initial_state),
+	     message)
+$$
+LANGUAGE SQL IMMUTABLE;
+
+COMMENT ON FUNCTION crypto_sign_update_agg2(bytea, bytea, bytea) IS
+'Internal helper function for crypto_sign_update_agg(bytea, bytea).  This
+initializes state to the state passed to the aggregate as a parameter,
+if it has not already been initialized.';
+
+CREATE OR REPLACE AGGREGATE crypto_sign_update_agg(message bytea)
+  (
+    SFUNC = crypto_sign_update_agg1,
+    STYPE = bytea,
+    PARALLEL = unsafe);
+
+COMMENT ON AGGREGATE crypto_sign_update_agg(bytea) IS
+'Multi-part message signing aggregate that returns a state which can
+then be finalised using crypto_sign_final() or to which other parts
+can be added crypto_sign_update() or another message signing aggregate
+function.
+
+Note that when signing mutli-part messages using aggregates, the order
+in which message parts is processed is critical.  You *must* ensure
+that the order of messages passed to the aggregate is invariant.';
+
+CREATE OR REPLACE AGGREGATE crypto_sign_update_agg(state bytea, message bytea)
+  (
+    SFUNC = crypto_sign_update_agg2,
+    STYPE = bytea,
+    PARALLEL = unsafe);
+
+COMMENT ON AGGREGATE crypto_sign_update_agg(bytea, bytea) IS
+'Multi-part message signing aggregate that returns a state which can
+then be finalised using crypto_sign_final() or to which other parts
+can be added crypto_sign_update() or another message signing aggregate
+function.
+
+The first argument to this aggregate is the input state.  This may be
+the result of a previous crypto_sign_update_agg(), a previous
+crypto_sign_update().
+
+Note that when signing mutli-part messages using aggregates, the order
+in which message parts is processed is critical.  You *must* ensure
+that the order of messages passed to the aggregate is invariant.';
+

--- a/pgsodium--1.0.0--1.1.0.sql
+++ b/pgsodium--1.0.0--1.1.0.sql
@@ -117,7 +117,7 @@ COMMENT ON FUNCTION crypto_sign_update_agg2(bytea, bytea, bytea) IS
 initializes state to the state passed to the aggregate as a parameter,
 if it has not already been initialized.';
 
-CREATE OR REPLACE AGGREGATE crypto_sign_update_agg(message bytea)
+CREATE AGGREGATE crypto_sign_update_agg(message bytea)
   (
     SFUNC = crypto_sign_update_agg1,
     STYPE = bytea,
@@ -133,7 +133,7 @@ Note that when signing mutli-part messages using aggregates, the order
 in which message parts is processed is critical.  You *must* ensure
 that the order of messages passed to the aggregate is invariant.';
 
-CREATE OR REPLACE AGGREGATE crypto_sign_update_agg(state bytea, message bytea)
+CREATE AGGREGATE crypto_sign_update_agg(state bytea, message bytea)
   (
     SFUNC = crypto_sign_update_agg2,
     STYPE = bytea,

--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -439,8 +439,8 @@ pgsodium_crypto_sign_verify_detached(PG_FUNCTION_ARGS)
 PG_FUNCTION_INFO_V1(pgsodium_crypto_sign_init);
 Datum pgsodium_crypto_sign_init(PG_FUNCTION_ARGS)
 {
-    bytea *result = (bytea *) palloc(VARHDRSZ +
-				     sizeof(crypto_sign_state));
+    bytea *result = _pgsodium_zalloc_bytea(VARHDRSZ +
+					   sizeof(crypto_sign_state));
     SET_VARSIZE(result, sizeof(crypto_sign_state));
     crypto_sign_init((crypto_sign_state *) VARDATA(result));
     PG_RETURN_BYTEA_P(result);

--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -454,7 +454,7 @@ Datum pgsodium_crypto_sign_update(PG_FUNCTION_ARGS)
     bytea *result = DatumGetByteaPCopy(state); // output state
     
     crypto_sign_update((crypto_sign_state *) VARDATA(result),
-		       (unsigned char *) VARDATA(msg_part),
+		       PGSODIUM_CHARDATA(msg_part),
 		       VARSIZE_ANY_EXHDR(msg_part));
     PG_RETURN_BYTEA_P(result);
 }
@@ -470,9 +470,9 @@ Datum pgsodium_crypto_sign_final_create(PG_FUNCTION_ARGS)
     bytea *result = _pgsodium_zalloc_bytea(result_size);
 	
     success = crypto_sign_final_create((crypto_sign_state *) VARDATA(state),
-				       (unsigned char*) VARDATA(result),
+				       PGSODIUM_CHARDATA(result),
 				       NULL,
-				       (unsigned char*) VARDATA(key));
+				       PGSODIUM_CHARDATA(key));
     if (success != 0)
 	ereport(
 	    ERROR,
@@ -491,12 +491,9 @@ Datum pgsodium_crypto_sign_final_verify(PG_FUNCTION_ARGS)
     bytea *key = PG_GETARG_BYTEA_P(2);
 	
     success = crypto_sign_final_verify((crypto_sign_state *) VARDATA(state),
-				       (unsigned char*) VARDATA(sig),
-				       (unsigned char*) VARDATA(key));
-    if (success == 0)
-	PG_RETURN_BOOL(true);
-    else
-	PG_RETURN_BOOL(false);	
+				       PGSODIUM_CHARDATA(sig),
+				       PGSODIUM_CHARDATA(key));
+    PG_RETURN_BOOL(success == 0);
 }
 
 PG_FUNCTION_INFO_V1(pgsodium_crypto_pwhash_saltgen);

--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -436,6 +436,68 @@ pgsodium_crypto_sign_verify_detached(PG_FUNCTION_ARGS)
 		PG_RETURN_BOOL(false);
 }
 
+PG_FUNCTION_INFO_V1(pgsodium_crypto_sign_init);
+Datum pgsodium_crypto_sign_init(PG_FUNCTION_ARGS)
+{
+    bytea *result = (bytea *) palloc(VARHDRSZ +
+				     sizeof(crypto_sign_state));
+    SET_VARSIZE(result, sizeof(crypto_sign_state));
+    crypto_sign_init((crypto_sign_state *) VARDATA(result));
+    PG_RETURN_BYTEA_P(result);
+}
+
+PG_FUNCTION_INFO_V1(pgsodium_crypto_sign_update);
+Datum pgsodium_crypto_sign_update(PG_FUNCTION_ARGS)
+{
+    bytea *state = PG_GETARG_BYTEA_P(0);       // input state
+    bytea *msg_part = PG_GETARG_BYTEA_P(1);
+    bytea *result = DatumGetByteaPCopy(state); // output state
+    
+    crypto_sign_update((crypto_sign_state *) VARDATA(result),
+		       (unsigned char *) VARDATA(msg_part),
+		       VARSIZE_ANY_EXHDR(msg_part));
+    PG_RETURN_BYTEA_P(result);
+}
+
+PG_FUNCTION_INFO_V1(pgsodium_crypto_sign_final_create);
+Datum pgsodium_crypto_sign_final_create(PG_FUNCTION_ARGS)
+{
+    int success;
+    bytea *state = PG_GETARG_BYTEA_P(0);
+    bytea *key = PG_GETARG_BYTEA_P(1);
+    size_t sig_size = crypto_sign_BYTES;
+    unsigned long long result_size = VARHDRSZ + sig_size;
+    bytea *result = _pgsodium_zalloc_bytea(result_size);
+	
+    success = crypto_sign_final_create((crypto_sign_state *) VARDATA(state),
+				       (unsigned char*) VARDATA(result),
+				       NULL,
+				       (unsigned char*) VARDATA(key));
+    if (success != 0)
+	ereport(
+	    ERROR,
+	    (errcode(ERRCODE_DATA_EXCEPTION),
+	     errmsg("unable to complete signature")));
+
+    PG_RETURN_BYTEA_P(result);
+}
+
+PG_FUNCTION_INFO_V1(pgsodium_crypto_sign_final_verify);
+Datum pgsodium_crypto_sign_final_verify(PG_FUNCTION_ARGS)
+{
+    int success;
+    bytea *state = PG_GETARG_BYTEA_P(0);
+    bytea *sig = PG_GETARG_BYTEA_P(1);
+    bytea *key = PG_GETARG_BYTEA_P(2);
+	
+    success = crypto_sign_final_verify((crypto_sign_state *) VARDATA(state),
+				       (unsigned char*) VARDATA(sig),
+				       (unsigned char*) VARDATA(key));
+    if (success == 0)
+	PG_RETURN_BOOL(true);
+    else
+	PG_RETURN_BOOL(false);	
+}
 
 PG_FUNCTION_INFO_V1(pgsodium_crypto_pwhash_saltgen);
 Datum

--- a/src/pgsodium.h
+++ b/src/pgsodium.h
@@ -94,6 +94,14 @@ Datum pgsodium_crypto_sign(PG_FUNCTION_ARGS);
 Datum pgsodium_crypto_sign_open(PG_FUNCTION_ARGS);
 Datum pgsodium_crypto_sign_detached(PG_FUNCTION_ARGS);
 Datum pgsodium_crypto_sign_verify_detached(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_init(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_update(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_final_create(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_final_verify(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_init(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_update(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_final_create(PG_FUNCTION_ARGS);
+Datum pgsodium_crypto_sign_final_verify(PG_FUNCTION_ARGS);
 
 /* Key Derivation */
 

--- a/test.sql
+++ b/test.sql
@@ -14,7 +14,7 @@ BEGIN;
 CREATE EXTENSION pgtap;
 CREATE EXTENSION pgsodium;
 
-SELECT plan(37);
+SELECT plan(38);
 
 SELECT lives_ok($$SELECT randombytes_random()$$, 'randombytes_random');
 SELECT lives_ok($$SELECT randombytes_uniform(10)$$, 'randombytes_uniform');
@@ -127,6 +127,12 @@ sig AS
 verify AS
   (
     SELECT crypto_sign_final_verify(p.state, s.sig, :'sign_public') as verify
+      FROM prep1 p
+     CROSS JOIN sig s
+  ),
+verify2 AS
+  (
+    SELECT crypto_sign_final_verify(p.state, s.sig, :'sign_public') as verify
       FROM prep2 p
      CROSS JOIN sig s
   ),
@@ -138,6 +144,9 @@ noverify AS
   )
 SELECT ok(verify, 'Multi-part signature')
   FROM verify
+UNION ALL
+SELECT ok(verify, 'Multi-part signature(2)')
+  FROM verify2
 UNION ALL
 -- Each time we generate state it will be different, even though sig
 -- can be verified.

--- a/test.sql
+++ b/test.sql
@@ -9,11 +9,12 @@
 \set ON_ERROR_STOP true
 \set QUIET 1
 
+
+BEGIN;
 CREATE EXTENSION pgtap;
 CREATE EXTENSION pgsodium;
 
-BEGIN;
-SELECT plan(34);
+SELECT plan(37);
 
 SELECT lives_ok($$SELECT randombytes_random()$$, 'randombytes_random');
 SELECT lives_ok($$SELECT randombytes_uniform(10)$$, 'randombytes_uniform');
@@ -86,6 +87,67 @@ SELECT is(crypto_sign_verify_detached(:'detached', :'sealed', :'sign_public'),
 
 SELECT is(crypto_sign_verify_detached(:'detached', 'xyzzy', :'sign_public'),
           false, 'crypto_sign_detached/verify (incorrect message)');
+
+-- Check Multi-part messages
+WITH parts(msg) AS
+  (
+    VALUES ('Hello Alice'),
+    	   ('Hello Bob'),
+    	   ('Hello Carol')
+  ),
+tampered(msg) AS
+  (
+    VALUES ('Hello Alice'),
+    	   ('Hello Bob'),
+    	   ('Hello CaRol')
+  ),
+prep1 AS
+  (
+    -- First form of aggregate
+    SELECT crypto_sign_update_agg(p.msg::bytea) state
+      FROM parts p
+  ),
+prep2 AS
+  (
+    -- Second form of aggregate
+    SELECT crypto_sign_update_agg(crypto_sign_init(), p.msg::bytea) state
+      FROM parts p
+  ),
+prepv AS
+  (
+    -- Second form of aggregate from tampered parts
+    SELECT crypto_sign_update_agg(crypto_sign_init(), t.msg::bytea) state
+      FROM tampered t
+  ),
+sig AS
+  (
+    SELECT crypto_sign_final_create(p.state, :'sign_secret') as sig
+      FROM prep1 p
+  ),
+verify AS
+  (
+    SELECT crypto_sign_final_verify(p.state, s.sig, :'sign_public') as verify
+      FROM prep2 p
+     CROSS JOIN sig s
+  ),
+noverify AS
+  (
+    SELECT crypto_sign_final_verify(p.state, s.sig, :'sign_public') as verify
+      FROM prepv p
+     CROSS JOIN sig s
+  )
+SELECT ok(verify, 'Multi-part signature')
+  FROM verify
+UNION ALL
+-- Each time we generate state it will be different, even though sig
+-- can be verified.
+SELECT isnt(p1.state, p2.state, 'Multi-part states differ')
+  FROM prep1 p1 CROSS JOIN prep2 p2
+UNION ALL
+SELECT ok(not verify, 'Multi-part signature detects tampering')
+  FROM noverify;
+
+
 
 SELECT lives_ok($$SELECT crypto_pwhash_saltgen()$$, 'crypto_pwhash_saltgen');
 


### PR DESCRIPTION
Michel,
This provides additional functions for multi-part message signing along with tests.

I moved the create extension statements in test.sql into the transaction block.  This means that after rollback, the extensions have been cleared out.  It makes stand-alone testing a little easier.

