### PR TITLE
Made local copy of state datum in crypto_sign_final_create.

### DIFF
--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -549,11 +549,16 @@ Datum pgsodium_crypto_sign_final_create(PG_FUNCTION_ARGS)
 	size_t result_size = VARHDRSZ + sig_size;
 	bytea* result = _pgsodium_zalloc_bytea(result_size);
 
+	// Make a copy of state so that we do not stomp over the
+	// user-facing datum.
+	bytea* local_state = DatumGetByteaPCopy(state); 
 	success = crypto_sign_final_create(
-		(crypto_sign_state*) VARDATA(state),
+		(crypto_sign_state*) VARDATA(local_state),
 		PGSODIUM_UCHARDATA(result),
 		NULL,
 		PGSODIUM_UCHARDATA(key));
+	pfree(local_state);
+	
 	if (success != 0)
 		ereport(
 			ERROR,


### PR DESCRIPTION
We need to copy the datum for state before it is used by crypto_sign_final_create().  Failing to do so leaves a datum that is available to sql which does not have its original value.  This is bad.

I haven't added a test for this, but have informally tested it in my own application and it appears to work - which it didn't previously.