### PR TITLE
Fix for crypto_sign_init bug found by marc.

### DIFF
--- a/src/sign.c
+++ b/src/sign.c
@@ -172,8 +172,8 @@ PG_FUNCTION_INFO_V1(pgsodium_crypto_sign_init);
 Datum pgsodium_crypto_sign_init(PG_FUNCTION_ARGS)
 {
 	bytea* result = _pgsodium_zalloc_bytea(
-		VARHDRSZ +sizeof(crypto_sign_state));
-	SET_VARSIZE(result, sizeof(crypto_sign_state));
+		VARHDRSZ + sizeof(crypto_sign_state));
+	SET_VARSIZE(result, VARHDRSZ + sizeof(crypto_sign_state));
 	crypto_sign_init((crypto_sign_state*) VARDATA(result));
 	PG_RETURN_BYTEA_P(result);
 }
@@ -211,6 +211,7 @@ Datum pgsodium_crypto_sign_final_create(PG_FUNCTION_ARGS)
 		NULL,
 		PGSODIUM_UCHARDATA(key));
 	pfree(local_state);
+	SET_VARSIZE(result, result_size);
 
 	ERRORIF(success != 0, "unable to complete signature");
 	PG_RETURN_BYTEA_P(result);


### PR DESCRIPTION
Michel,
I found a bug in crypto_sign_init().  I had incorrectly set the VARSIZE attribute of the bytea result.  This is now fixed.  I noticed also that VARSIZE was not explicitly set in crypto_sign_final_create().  I assume that _pgsodium_zalloc_bytea() does this, but I prefer to see the explicit assignment inline.  Feel free to edit as you see fit.

__
Marc