### PR TITLE
Add Doppler's SecretOps Platform as a getkey_scripts example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ pgsodium also comes with example scripts for:
   - [Google Cloud's Cloud Key
     Management](getkey_scripts/pgsodium_getkey_gcp.sh).
 
-  - [Doppler SecretOps Platform](getkey_scripts/pgsodium_getkey_aws.sh).
+  - [Doppler SecretOps Platform](getkey_scripts/pgsodium_getkey_doppler.sh).
 
   - [Zymbit Zymkey 4i Hardware Security
     Module](getkey_scripts/pgsodium_getkey_zmk.sh).

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ pgsodium also comes with example scripts for:
   - [Google Cloud's Cloud Key
     Management](getkey_scripts/pgsodium_getkey_gcp.sh).
 
+  - [Doppler SecretOps Platform](getkey_scripts/pgsodium_getkey_aws.sh).
+
   - [Zymbit Zymkey 4i Hardware Security
     Module](getkey_scripts/pgsodium_getkey_zmk.sh).
 
@@ -1046,3 +1048,4 @@ The Toorani-Beheshti signcryption scheme achieves this using a single
 key pair per device, with forward security and public verifiability.
 
 [C API Documentation](https://github.com/jedisct1/libsodium-signcryption)
+

--- a/getkey_scripts/pgsodium_getkey_doppler.sh
+++ b/getkey_scripts/pgsodium_getkey_doppler.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+HERE=`pwd`
+KEY_ID=${KEY_ID:-alias/pgsodium}
+ENCRYPTED_ROOT_KEY_FILE=${ENCRYPTED_ROOT_KEY_FILE:-$HERE/pgsodium_encrypted_root.key}
+
+if [ ! -f "$ENCRYPTED_ROOT_KEY_FILE" ]; then
+  # Expects the Doppler CLI to be installed: https://docs.doppler.com/docs/install-cli
+  #
+  # Expects the `DOPPLER_TOKEN` to be available as environment variable which will
+  # authenticate the Doppler CLI: https://docs.doppler.com/docs/service-tokens
+  doppler secrets get ENCRYPTION_KEY --plain > $ENCRYPTED_ROOT_KEY_FILE
+fi
+
+cat $ENCRYPTED_ROOT_KEY_FILE


### PR DESCRIPTION
Doppler is a SecretOps platform that gives developers and their teams a central source of truth for their secrets. This PR adds Doppler to the `getkey_scripts`.