### PR TITLE
fix: crash on macos 13.0.1

### DIFF
--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -78,7 +78,7 @@ void
 _PG_init (void)
 {
 	FILE       *fp;
-	char       *secret_buf;
+	char       *secret_buf = NULL;
 	size_t      secret_len = 0;
 	size_t      char_read;
 	char       *path;


### PR DESCRIPTION
This uninitialized pointer `secret_buf` caused crash when `getline()` is called on macOS 13.0.1. As [the man page said](https://man7.org/linux/man-pages/man3/getline.3.html):

> If *lineptr is set to NULL before the call, then getline() will allocate a buffer for storing the line.

So it's better to always initialize pointer to `NULL`.