### PR TITLE
Make extension relocatable during installation

### DIFF
--- a/pgsodium.control
+++ b/pgsodium.control
@@ -2,4 +2,3 @@
 comment = 'Postgres extension for libsodium functions'
 default_version = '3.0.7'
 relocatable = false
-schema = pgsodium

--- a/sql/pgsodium--2.0.2--3.0.0.sql
+++ b/sql/pgsodium--2.0.2--3.0.0.sql
@@ -539,7 +539,7 @@ $$
   SET search_path='pg_catalog'
 ;
 
-CREATE EVENT TRIGGER @extschema@_trg_mask_update
+CREATE EVENT TRIGGER pgsodium_trg_mask_update
   ON ddl_command_end
   WHEN TAG IN (
     'ALTER TABLE',

--- a/sql/pgsodium--3.0.2--3.0.3.sql
+++ b/sql/pgsodium--3.0.2--3.0.3.sql
@@ -1,3 +1,3 @@
 
-INSERT INTO pgsodium.key (status, key_id, key_context, comment)
+INSERT INTO @extschema@.key (status, key_id, key_context, comment)
 VALUES ('default', 1, 'pgsodium', 'This is the default key used for vault.secrets');

--- a/test/hmac.sql
+++ b/test/hmac.sql
@@ -32,10 +32,10 @@ select is(crypto_auth_hmacsha256_verify(:'hmac256', 'food', 42), true, 'hmac256 
 select is(crypto_auth_hmacsha256_verify(:'hmac256', 'fo0d', 42), false, 'hmac256 not verified');
 
 select crypto_auth_hmacsha256_keygen() extkey256 \gset
-select * from pgsodium.create_key('hmacsha256', raw_key:=:'extkey256') \gset extkey256_
+select * from :"extschema".create_key('hmacsha256', raw_key:=:'extkey256') \gset extkey256_
 
 select crypto_auth_hmacsha512_keygen() extkey512 \gset
-select * from pgsodium.create_key('hmacsha512', raw_key:=:'extkey512') \gset extkey512_
+select * from :"extschema".create_key('hmacsha512', raw_key:=:'extkey512') \gset extkey512_
 
 select crypto_auth_hmacsha512('food', :'extkey512_id'::uuid) hmac512 \gset
 

--- a/test/test.sql
+++ b/test/test.sql
@@ -9,20 +9,19 @@
 \set ON_ERROR_STOP on
 -- \set QUIET 1
 
+\set extschema :extschema
+SELECT CASE WHEN :'extschema' = ':extschema'
+       THEN 'pgsodium'
+       ELSE :'extschema'
+       END AS extschema \gset
+
 CREATE EXTENSION IF NOT EXISTS pgtap;
+DROP ROLE IF EXISTS bobo;
 
-BEGIN;
-SELECT plan(1);
-CREATE SCHEMA bogus;
-SELECT throws_ok($$CREATE EXTENSION pgsodium WITH SCHEMA bogus$$,
-                 '0A000', 'extension "pgsodium" must be installed in schema "pgsodium"',
-                 'cannot install pgsodium in any other schema');
-SELECT * FROM finish();
-ROLLBACK;
+CREATE SCHEMA IF NOT EXISTS :"extschema";
+CREATE EXTENSION IF NOT EXISTS pgsodium SCHEMA :"extschema";
 
-CREATE EXTENSION pgsodium;
-
-SET search_path = pgsodium, public;
+SET search_path = :'extschema', public;
 
 SELECT EXISTS (SELECT * FROM pg_settings
     WHERE name = 'shared_preload_libraries'


### PR DESCRIPTION
Hi,

While studying pgsodium, I found that the extension schema location is using sometime the relocatable form `@extschema@` and sometime the fixed one `pgsodium`. Sometime, both forms appear in the same function.

If the extension is truly non relocatable, using `@extschema@` is a useless pain. If it can be relocatable, I suppose we just have to fix it in the installation script and adjust tests to make sure it works as expected.

I took the liberty to implement the relocatable form, just to start the discussion. If you want to run your tests with a non-default schema, just run: `psql -f test/test.sql -v extschema=anotherschema`.

If the extension must not be relocatable, I can handle the cleanup as well.