### PR TITLE
Fix valid_key view to filter out expired keys

### DIFF
--- a/sql/pgsodium--3.0.7--3.0.8.sql
+++ b/sql/pgsodium--3.0.7--3.0.8.sql
@@ -63,3 +63,9 @@ Note that when signing mutli-part messages using aggregates, the order
 in which message parts is processed is critical. You *must* ensure
 that the order of messages passed to the aggregate is invariant.';
     
+
+CREATE OR REPLACE VIEW pgsodium.valid_key AS
+  SELECT id, name, status, key_type, key_id, key_context, created, expires, associated_data
+    FROM pgsodium.key
+   WHERE  status IN ('valid', 'default')
+     AND CASE WHEN expires IS NULL THEN true ELSE expires > now() END;

--- a/test/tce.sql
+++ b/test/tce.sql
@@ -77,7 +77,7 @@ SELECT lives_ok(
 SELECT * FROM finish();
 COMMIT;
 
-\c postgres bobo
+\c - bobo
 
 BEGIN;
 SELECT plan(9);
@@ -153,6 +153,6 @@ SELECT lives_ok(
 
 SELECT * FROM finish();
 
-\c postgres postgres
+\c - postgres
 DROP SCHEMA private CASCADE;
 \endif


### PR DESCRIPTION
A key is valid at far as its expires date is greater than current date and time.

Fixes #41