### PR TITLE
Cleanup @extschema@ as pgsodium is not relocatable

### DIFF
--- a/sql/pgsodium--3.0.0--3.0.2.sql
+++ b/sql/pgsodium--3.0.0--3.0.2.sql
@@ -1,3 +1,3 @@
 
-ALTER FUNCTION @extschema@.crypto_aead_det_encrypt(message bytea, additional bytea, key_uuid uuid, nonce bytea) CALLED ON NULL INPUT;
-ALTER FUNCTION @extschema@.crypto_aead_det_decrypt(message bytea, additional bytea, key_uuid uuid, nonce bytea) CALLED ON NULL INPUT;  
+ALTER FUNCTION pgsodium.crypto_aead_det_encrypt(message bytea, additional bytea, key_uuid uuid, nonce bytea) CALLED ON NULL INPUT;
+ALTER FUNCTION pgsodium.crypto_aead_det_decrypt(message bytea, additional bytea, key_uuid uuid, nonce bytea) CALLED ON NULL INPUT;  

--- a/sql/pgsodium--3.0.5--3.0.6.sql
+++ b/sql/pgsodium--3.0.5--3.0.6.sql
@@ -1,11 +1,11 @@
-DROP EVENT TRIGGER  @extschema@_trg_mask_update;
+DROP EVENT TRIGGER  pgsodium_trg_mask_update;
 
-CREATE EVENT TRIGGER @extschema@_trg_mask_update
+CREATE EVENT TRIGGER pgsodium_trg_mask_update
   ON ddl_command_end
   WHEN TAG IN (
     'SECURITY LABEL'
   )
-  EXECUTE PROCEDURE @extschema@.trg_mask_update()
+  EXECUTE PROCEDURE pgsodium.trg_mask_update()
 ;
 
 ALTER EXTENSION pgsodium DROP FUNCTION pgsodium.key_encrypt_secret();

--- a/sql/pgsodium--3.0.6--3.0.7.sql
+++ b/sql/pgsodium--3.0.6--3.0.7.sql
@@ -194,11 +194,11 @@ END;
   SET search_path=''
   ;
     
-CREATE OR REPLACE FUNCTION @extschema@.mask_role(masked_role regrole, source_name text, view_name text)
+CREATE OR REPLACE FUNCTION pgsodium.mask_role(masked_role regrole, source_name text, view_name text)
   RETURNS void AS
   $$
   DECLARE
-  mask_schema REGNAMESPACE = '@extschema@_masks';
+  mask_schema REGNAMESPACE = 'pgsodium_masks';
   source_schema REGNAMESPACE = (regexp_split_to_array(source_name, '\.'))[1];
 BEGIN
   EXECUTE format(


### PR DESCRIPTION
As discussed in #44, here is some cleanup to remove useless `@extschema@`, making the extension schema `pgsodium` mandatory.