### PR TITLE
Fix error message on bad label for a table

### DIFF
--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -20,9 +20,15 @@ pgsodium_object_relabel (const ObjectAddress * object, const char *seclabel)
 	  case RelationRelationId:
 
 		  /* SECURITY LABEL FOR pgsodium ON TABLE ...' */
-		  if (object->objectSubId == 0
-			  && pg_strncasecmp (seclabel, "DECRYPT WITH VIEW", 17) == 0)
-			  return;
+		  if (object->objectSubId == 0)
+		  {
+			  if (pg_strncasecmp (seclabel, "DECRYPT WITH VIEW", 17) == 0)
+				  return;
+			  ereport (ERROR,
+				  (errcode (ERRCODE_INVALID_NAME),
+					  errmsg ("'%s' is not a valid label for a table",
+						  seclabel)));
+		  }
 
 		  /* SECURITY LABEL FOR pgsodium ON COLUMN t.i IS '...' */
 		  if (pg_strncasecmp (seclabel, "ENCRYPT WITH", 12) == 0)


### PR DESCRIPTION
When setting an invalid label on a table, the error message was reporting an invalid label for a column.