### PR TITLE
dump key id sequence, update test to 3.1.6

### DIFF
--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
     "name": "pgsodium",
     "abstract": "Postgres extension for libsodium functions",
     "description": "pgsodium is a PostgreSQL extension that exposes modern libsodium based cryptographic functions to SQL.",
-    "version": "3.1.5",
+    "version": "3.1.6",
     "maintainer": [
         "Michel Pelletier <pelletier.michel@gmail.com>"
     ],
@@ -13,7 +13,7 @@
             "abstract": "Postgres extension for libsodium functions",
             "file": "src/pgsodium.h",
             "docfile": "README.md",
-            "version": "3.1.5"
+            "version": "3.1.6"
         }
     },
     "prereqs": {

--- a/pgsodium.control
+++ b/pgsodium.control
@@ -1,5 +1,5 @@
 # pgsodium extension
 comment = 'Postgres extension for libsodium functions'
-default_version = '3.1.5'
+default_version = '3.1.6'
 relocatable = false
 schema = pgsodium

--- a/sql/pgsodium--3.1.5--3.1.6.sql
+++ b/sql/pgsodium--3.1.5--3.1.6.sql
@@ -1,0 +1,2 @@
+
+SELECT pg_catalog.pg_extension_config_dump('pgsodium.key_key_id_seq', '');

--- a/test/pgsodium_schema.sql
+++ b/test/pgsodium_schema.sql
@@ -9,7 +9,7 @@ SELECT plan(1748);
 
 
 ---- EXTENSION VERSION
-SELECT results_eq('SELECT pgsodium.version()', $$VALUES ('3.1.5'::text)$$, 'Version of pgsodium is 3.1.5');
+SELECT results_eq('SELECT pgsodium.version()', $$VALUES ('3.1.6'::text)$$, 'Version of pgsodium is 3.1.6');
 
 
 ---- EXTENSION OBJECTS


### PR DESCRIPTION
Quick fix to `pgsodium.key` table not dumping its key id sequence.