### PR TITLE
Use explicit schema in format calls in DO blocks

### DIFF
--- a/sql/pgsodium--1.1.1--1.2.0.sql
+++ b/sql/pgsodium--1.1.1--1.2.0.sql
@@ -107,7 +107,7 @@ BEGIN
               'pgsodium_keymaker']
 	LOOP
 		IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = new_role) THEN
-		    EXECUTE format($i$
+		    EXECUTE pg_catalog.format($i$
 			CREATE ROLE %I WITH
 				NOLOGIN
 				NOSUPERUSER
@@ -152,7 +152,7 @@ BEGIN
 		'crypto_sign_new_keypair'
 	]
 	LOOP
-		EXECUTE format($i$
+		EXECUTE pg_catalog.format($i$
 			REVOKE ALL ON FUNCTION %s FROM PUBLIC;
 			GRANT EXECUTE ON FUNCTION %s TO pgsodium_keymaker;
 		$i$, func, func);
@@ -188,7 +188,7 @@ BEGIN
 		'crypto_sign_update_agg2'
 	]
 	LOOP
-		EXECUTE format($i$
+		EXECUTE pg_catalog.format($i$
 			REVOKE ALL ON FUNCTION %s FROM PUBLIC;
 			GRANT EXECUTE ON FUNCTION %s TO pgsodium_keyholder;
 		$i$, func, func);
@@ -220,7 +220,7 @@ BEGIN
 		'crypto_shorthash'
 	]
 	LOOP
-		EXECUTE format($i$
+		EXECUTE pg_catalog.format($i$
 			REVOKE ALL ON FUNCTION %s FROM PUBLIC;
 			GRANT EXECUTE ON FUNCTION %s TO pgsodium_keyiduser;
 		$i$, func, func);

--- a/sql/pgsodium--1.2.0--2.0.0.sql
+++ b/sql/pgsodium--1.2.0--2.0.0.sql
@@ -169,7 +169,7 @@ BEGIN
         'crypto_aead_det_keygen'
 	]
 	LOOP
-		EXECUTE format($i$
+		EXECUTE pg_catalog.format($i$
 			REVOKE ALL ON FUNCTION %s FROM PUBLIC;
 			GRANT EXECUTE ON FUNCTION %s TO pgsodium_keymaker;
 		$i$, func, func);
@@ -194,7 +194,7 @@ BEGIN
     'crypto_aead_det_decrypt(bytea, bytea, bytea, bytea)'
 	]
 	LOOP
-		EXECUTE format($i$
+		EXECUTE pg_catalog.format($i$
 			REVOKE ALL ON FUNCTION %s FROM PUBLIC;
 			GRANT EXECUTE ON FUNCTION %s TO pgsodium_keyholder;
 		$i$, func, func);
@@ -214,7 +214,7 @@ BEGIN
     'crypto_aead_det_decrypt(bytea, bytea, bigint, bytea, bytea)'
 	]
 	LOOP
-		EXECUTE format($i$
+		EXECUTE pg_catalog.format($i$
 			REVOKE ALL ON FUNCTION %s FROM PUBLIC;
 			GRANT EXECUTE ON FUNCTION %s TO pgsodium_keyiduser;
 		$i$, func, func);

--- a/sql/pgsodium--3.0.4--3.0.5.sql
+++ b/sql/pgsodium--3.0.4--3.0.5.sql
@@ -870,7 +870,7 @@ BEGIN
         'pgsodium.crypto_aead_ietf_decrypt(bytea, bytea, bytea, uuid)'
     ]
     LOOP
-        EXECUTE format($i$
+        EXECUTE pg_catalog.format($i$
             REVOKE ALL ON FUNCTION %s FROM PUBLIC;
             GRANT EXECUTE ON FUNCTION %s TO pgsodium_keyiduser;
         $i$, func, func);


### PR DESCRIPTION
The DO blocks in the version update scripts did not sufficiently lock down search_path for the format calls allowing injection of a malicious format function to be executed during upgrades.