### PR TITLE
Fix sql injection vulnerability in pgsodium.mask_role

### DIFF
--- a/sql/pgsodium--3.1.9--3.1.10.sql
+++ b/sql/pgsodium--3.1.9--3.1.10.sql
@@ -1,0 +1,25 @@
+
+CREATE OR REPLACE FUNCTION pgsodium.mask_role(masked_role regrole, source_name text, view_name text)
+  RETURNS void AS
+  $$
+BEGIN
+  EXECUTE format(
+    'GRANT SELECT ON pgsodium.key TO %s',
+    masked_role);
+
+  EXECUTE format(
+    'GRANT pgsodium_keyiduser, pgsodium_keyholder TO %s',
+    masked_role);
+
+  EXECUTE format(
+    'GRANT ALL ON %I TO %s',
+    view_name,
+    masked_role);
+  RETURN;
+END
+$$
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path='pg_catalog, pg_temp'
+;
+


### PR DESCRIPTION
pgsodium.mask_role does not properly quote the view_name argument before using it in a generated sql query. This is especially critical since mask_role is a security definer function.