### PR TITLE
Add IP address encryption (crypto_ipcrypt) and bump to libsodium 1.0.22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,9 @@ jobs:
 
   #     - name: Install dependencies
   #       run: |
-  #         Invoke-WebRequest -URI https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip -OutFile libsodium-1.0.18-stable-msvc.zip
-  #         tar -xf libsodium-1.0.18-stable-msvc.zip
-  #         rm libsodium-1.0.18-stable-msvc.zip
+  #         Invoke-WebRequest -URI https://download.libsodium.org/libsodium/releases/libsodium-1.0.22-stable-msvc.zip -OutFile libsodium-1.0.22-stable-msvc.zip
+  #         tar -xf libsodium-1.0.22-stable-msvc.zip
+  #         rm libsodium-1.0.22-stable-msvc.zip
   #         cp .\libsodium\x64\Release\v143\dynamic\libsodium.dll $env:PGROOT\lib
   #         Invoke-WebRequest -URI https://github.com/theory/pgtap/archive/refs/tags/v1.2.0.zip -OutFile pgtap.zip
   #         tar -xf pgtap.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   test_linux:
-    name: Linux build and tests
+    name: tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,12 +23,12 @@ RUN curl -s -L https://ftp.postgresql.org/pub/source/v${version}/postgresql-${ve
     cd .. && rm -rf postgresql-${version}
 
 # Build libsodium
-RUN curl -s -L https://github.com/jedisct1/libsodium/releases/download/1.0.20-RELEASE/libsodium-1.0.20.tar.gz | tar zxf - && \
-    cd libsodium-1.0.20 && \
+RUN curl -s -L https://github.com/jedisct1/libsodium/releases/download/1.0.22-RELEASE/libsodium-1.0.22.tar.gz | tar zxf - && \
+    cd libsodium-1.0.22 && \
     ./configure --prefix=/usr/local && \
     make -j$(nproc) && \
     make install && \
-    cd .. && rm -rf libsodium-1.0.20
+    cd .. && rm -rf libsodium-1.0.22
 
 # Build pgTAP (for testing)
 RUN curl -s -L https://github.com/theory/pgtap/archive/v1.2.0.tar.gz | tar zxf - && \

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -15,7 +15,7 @@ RUN git clone --branch REL_${version}_STABLE https://github.com/postgres/postgre
     && make -j 4 && make install
 
 RUN curl -s -L https://github.com/theory/pgtap/archive/v1.1.0.tar.gz | tar zxvf - && cd pgtap-1.1.0 && make && make install
-RUN curl -s -L https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz | tar zxvf - && cd libsodium-1.0.18 && ./configure && make check && make install
+RUN curl -s -L https://github.com/jedisct1/libsodium/releases/download/1.0.22-RELEASE/libsodium-1.0.22.tar.gz | tar zxvf - && cd libsodium-1.0.22 && ./configure && make check && make install
 RUN mkdir "/pgsodium"
 WORKDIR "/pgsodium"
 COPY . .

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
     "name": "pgsodium",
     "abstract": "Postgres extension for libsodium functions",
     "description": "pgsodium is a PostgreSQL extension that exposes modern libsodium based cryptographic functions to SQL.",
-    "version": "3.1.9",
+    "version": "3.1.11",
     "maintainer": [
         "Michel Pelletier <pelletier.michel@gmail.com>"
     ],
@@ -13,7 +13,7 @@
             "abstract": "Postgres extension for libsodium functions",
             "file": "src/pgsodium.h",
             "docfile": "README.md",
-            "version": "3.1.9"
+            "version": "3.1.11"
         }
     },
     "prereqs": {

--- a/README.md
+++ b/README.md
@@ -1118,6 +1118,56 @@ Example:
 
 [C API Documentation](https://doc.libsodium.org/hashing)
 
+## IP Address Encryption
+
+pgsodium exposes the libsodium `crypto_ipcrypt_*` family, which encrypts and
+anonymizes IP addresses following the
+[ipcrypt-std](https://ipcrypt-std.github.io) specification. Addresses are
+processed as their 16 byte binary form (IPv4 addresses are represented as
+IPv4-mapped IPv6 addresses). The `crypto_ipcrypt_ip2bin()` and
+`crypto_ipcrypt_bin2ip()` helpers convert between text and binary forms:
+
+    SELECT crypto_ipcrypt_ip2bin('192.0.2.1');
+    SELECT crypto_ipcrypt_bin2ip(crypto_ipcrypt_ip2bin('2001:db8::1'));
+
+Four variants are provided, each with a different privacy/utility trade-off:
+
+| Variant | Function prefix | Key | Output | Properties |
+| --- | --- | --- | --- | --- |
+| Deterministic | `crypto_ipcrypt_` | 16 bytes | 16 bytes | Format-preserving. Same input always yields the same output (joinable, but reveals equality). |
+| Prefix-preserving | `crypto_ipcrypt_pfx_` | 32 bytes | 16 bytes | Format-preserving and preserves network-prefix relationships (subnet structure stays visible). |
+| Non-deterministic | `crypto_ipcrypt_nd_` | 16 bytes | 24 bytes | Randomized per call via an 8 byte tweak (KIASU-BC). Unlinkable. |
+| Extended non-deterministic | `crypto_ipcrypt_ndx_` | 32 bytes | 32 bytes | Randomized per call via a 16 byte tweak (AES-XTS). Largest birthday bound. |
+
+For the two format-preserving variants there are `inet` overloads that accept
+and return an `inet`, in addition to the `bytea` forms:
+
+    -- generate a key and prefix-preservingly encrypt an address
+    SELECT crypto_ipcrypt_pfx_encrypt('203.0.113.42'::inet, crypto_ipcrypt_pfx_keygen());
+
+    -- deterministic encryption round-trip on the binary form
+    SELECT crypto_ipcrypt_keygen() detkey \gset
+    SELECT crypto_ipcrypt_decrypt(
+             crypto_ipcrypt_encrypt(crypto_ipcrypt_ip2bin('192.0.2.1'), :'detkey'::bytea),
+             :'detkey'::bytea);
+
+The non-deterministic variants take a caller-supplied tweak (generate one with
+`crypto_ipcrypt_nd_tweakgen()` / `crypto_ipcrypt_ndx_tweakgen()`); the tweak is
+prepended to the ciphertext, so decryption needs only the ciphertext and key:
+
+    SELECT crypto_ipcrypt_nd_keygen() ndkey \gset
+    SELECT crypto_ipcrypt_nd_encrypt(crypto_ipcrypt_ip2bin('192.0.2.1'),
+             crypto_ipcrypt_nd_tweakgen(), :'ndkey'::bytea) ndct \gset
+    SELECT crypto_ipcrypt_nd_decrypt(:'ndct'::bytea, :'ndkey'::bytea);
+
+As with the other primitives, every variant also has server-managed key
+overloads: a `key_id bigint` (plus optional 8 byte `context`) form that derives
+the key from the server root key, and a `key_uuid uuid` form that looks the key
+up in the pgsodium key table. Use `create_key('ipcrypt-det')`,
+`'ipcrypt-pfx'`, `'ipcrypt-nd'` or `'ipcrypt-ndx'` to create managed keys.
+
+[ipcrypt-std specification](https://ipcrypt-std.github.io)
+
 ## Password hashing
 
     SELECT lives_ok($$SELECT crypto_pwhash_saltgen()$$, 'crypto_pwhash_saltgen');

--- a/build/windows.md
+++ b/build/windows.md
@@ -1,7 +1,7 @@
 #### Building on Windows
 ---------
 
-- Download [libsodium](https://download.libsodium.org/libsodium/releases/libsodium-1.0.18-stable-msvc.zip) >= 1.018 and unzip
+- Download [libsodium](https://download.libsodium.org/libsodium/releases/libsodium-1.0.22-stable-msvc.zip) >= 1.0.18 and unzip
 - Download and run the [postgresql installer](https://www.postgresql.org/download/windows/)
 - From the `/pgsodium/build` directory, run `msbuild` on `pgsodium.vcxproj`
 	- `msbuild` can be invoked though the *x64 Native Tools Command Prompt for VS 2022*

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -3,7 +3,7 @@ FROM postgres:${version}
 ARG version
 
 RUN apt-get update && apt-get install -y make git postgresql-server-dev-${version} curl build-essential libreadline-dev pgxnclient python3-notebook jupyter jupyter-core python3-pip
-RUN curl -s -L https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz | tar zxvf - && cd libsodium-1.0.18 && ./configure && make check && make install
+RUN curl -s -L https://github.com/jedisct1/libsodium/releases/download/1.0.22-RELEASE/libsodium-1.0.22.tar.gz | tar zxvf - && cd libsodium-1.0.22 && ./configure && make check && make install
 
 # RUN curl -s -L https://github.com/theory/pgtap/archive/v1.1.0.tar.gz | tar zxvf - && cd pgtap-1.1.0 && make && make install
 # RUN curl -s -L https://gitlab.com/dalibo/postgresql_anonymizer/-/archive/0.6.0/postgresql_anonymizer-0.6.0.tar.gz | tar zxvf - && cd postgresql_anonymizer-0.6.0 && make extension && make install

--- a/extension/pgsodium--3.1.10--3.1.11.sql
+++ b/extension/pgsodium--3.1.10--3.1.11.sql
@@ -1,0 +1,381 @@
+-- pgsodium 3.1.11: IP address encryption (libsodium crypto_ipcrypt_*)
+--
+-- Implements the ipcrypt-std family (https://ipcrypt-std.github.io):
+--   * deterministic  (AES-128, format-preserving)
+--   * pfx            (prefix-preserving)
+--   * nd             (KIASU-BC, non-deterministic, 8 byte tweak)
+--   * ndx            (AES-XTS, non-deterministic, 16 byte tweak)
+--
+-- IP addresses are handled as the 16 byte binary form; the ip2bin/bin2ip
+-- helpers convert to/from text, and inet overloads are provided for the two
+-- format-preserving variants.
+
+-- New key types for the managed key infrastructure (one per variant).
+ALTER TYPE pgsodium.key_type ADD VALUE 'ipcrypt-det';
+ALTER TYPE pgsodium.key_type ADD VALUE 'ipcrypt-pfx';
+ALTER TYPE pgsodium.key_type ADD VALUE 'ipcrypt-nd';
+ALTER TYPE pgsodium.key_type ADD VALUE 'ipcrypt-ndx';
+
+-- Conversion helpers between text IP addresses and the 16 byte binary form.
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ip2bin(ip text)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_ip2bin'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_bin2ip(bin bytea)
+  RETURNS text
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_bin2ip'
+  LANGUAGE C IMMUTABLE STRICT;
+
+-- ===========================================================================
+-- Deterministic variant (key 16, input/output 16, format-preserving)
+-- ===========================================================================
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_keygen()
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_keygen'
+  LANGUAGE C VOLATILE;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_encrypt(ip bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_encrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_decrypt(ip bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_decrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_encrypt(ip bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_encrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_decrypt(ip bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_decrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_encrypt(ip bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-det';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_encrypt(ip, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_encrypt(ip, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_decrypt(ip bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-det';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_decrypt(ip, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_decrypt(ip, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+-- inet overloads (format-preserving): encrypt/decrypt inet -> inet
+CREATE FUNCTION pgsodium.crypto_ipcrypt_encrypt(ip inet, key bytea)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_encrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key))::inet;
+$$ LANGUAGE sql IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_decrypt(ip inet, key bytea)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_decrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key))::inet;
+$$ LANGUAGE sql IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_encrypt(ip inet, key_uuid uuid)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_encrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key_uuid))::inet;
+$$ LANGUAGE sql STABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_decrypt(ip inet, key_uuid uuid)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_decrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key_uuid))::inet;
+$$ LANGUAGE sql STABLE STRICT;
+
+-- ===========================================================================
+-- Prefix-preserving variant (key 32, input/output 16, prefix-preserving)
+-- ===========================================================================
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_keygen()
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_pfx_keygen'
+  LANGUAGE C VOLATILE;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_encrypt(ip bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_pfx_encrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_decrypt(ip bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_pfx_decrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_encrypt(ip bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_pfx_encrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_decrypt(ip bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_pfx_decrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_encrypt(ip bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-pfx';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_pfx_encrypt(ip, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_pfx_encrypt(ip, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_decrypt(ip bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-pfx';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_pfx_decrypt(ip, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_pfx_decrypt(ip, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_encrypt(ip inet, key bytea)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_pfx_encrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key))::inet;
+$$ LANGUAGE sql IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_decrypt(ip inet, key bytea)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_pfx_decrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key))::inet;
+$$ LANGUAGE sql IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_encrypt(ip inet, key_uuid uuid)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_pfx_encrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key_uuid))::inet;
+$$ LANGUAGE sql STABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_pfx_decrypt(ip inet, key_uuid uuid)
+  RETURNS inet AS $$
+  SELECT pgsodium.crypto_ipcrypt_bin2ip(
+           pgsodium.crypto_ipcrypt_pfx_decrypt(
+             pgsodium.crypto_ipcrypt_ip2bin(host(ip)), key_uuid))::inet;
+$$ LANGUAGE sql STABLE STRICT;
+
+-- ===========================================================================
+-- Non-deterministic variant ND (key 16, tweak 8, input 16, output 24)
+-- ===========================================================================
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_keygen()
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_nd_keygen'
+  LANGUAGE C VOLATILE;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_tweakgen()
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_nd_tweakgen'
+  LANGUAGE C VOLATILE;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_encrypt(ip bytea, tweak bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_nd_encrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_decrypt(ciphertext bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_nd_decrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_encrypt(ip bytea, tweak bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_nd_encrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_decrypt(ciphertext bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_nd_decrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_encrypt(ip bytea, tweak bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-nd';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_nd_encrypt(ip, tweak, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_nd_encrypt(ip, tweak, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_nd_decrypt(ciphertext bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-nd';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_nd_decrypt(ciphertext, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_nd_decrypt(ciphertext, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+-- ===========================================================================
+-- Extended non-deterministic variant NDX (key 32, tweak 16, input 16, output 32)
+-- ===========================================================================
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_keygen()
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_ndx_keygen'
+  LANGUAGE C VOLATILE;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_tweakgen()
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_ndx_tweakgen'
+  LANGUAGE C VOLATILE;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_encrypt(ip bytea, tweak bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_ndx_encrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_decrypt(ciphertext bytea, key bytea)
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_ndx_decrypt'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_encrypt(ip bytea, tweak bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_ndx_encrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_decrypt(ciphertext bytea, key_id bigint, context bytea = 'pgsodium')
+  RETURNS bytea
+  AS '$libdir/pgsodium', 'pgsodium_crypto_ipcrypt_ndx_decrypt_by_id'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_encrypt(ip bytea, tweak bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-ndx';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_ndx_encrypt(ip, tweak, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_ndx_encrypt(ip, tweak, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+CREATE FUNCTION pgsodium.crypto_ipcrypt_ndx_decrypt(ciphertext bytea, key_uuid uuid)
+  RETURNS bytea AS $$
+DECLARE
+  key pgsodium.decrypted_key;
+BEGIN
+  SELECT * INTO STRICT key FROM pgsodium.decrypted_key v
+    WHERE id = key_uuid AND key_type = 'ipcrypt-ndx';
+  IF key.decrypted_raw_key IS NOT NULL THEN
+    RETURN pgsodium.crypto_ipcrypt_ndx_decrypt(ciphertext, key.decrypted_raw_key);
+  END IF;
+  RETURN pgsodium.crypto_ipcrypt_ndx_decrypt(ciphertext, key.key_id, key.key_context);
+END;
+$$ LANGUAGE plpgsql STRICT STABLE SECURITY DEFINER SET search_path = '';
+
+-- ===========================================================================
+-- Permissions
+-- ===========================================================================
+
+-- by_id (bigint), uuid and inet/uuid overloads are restricted to
+-- pgsodium_keyiduser, matching the convention for managed-key functions.
+DO $$
+DECLARE
+  func text;
+BEGIN
+  FOREACH func IN ARRAY ARRAY[
+    'pgsodium.crypto_ipcrypt_encrypt(bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_decrypt(bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_encrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_decrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_encrypt(inet, uuid)',
+    'pgsodium.crypto_ipcrypt_decrypt(inet, uuid)',
+    'pgsodium.crypto_ipcrypt_pfx_encrypt(bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_pfx_decrypt(bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_pfx_encrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_pfx_decrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_pfx_encrypt(inet, uuid)',
+    'pgsodium.crypto_ipcrypt_pfx_decrypt(inet, uuid)',
+    'pgsodium.crypto_ipcrypt_nd_encrypt(bytea, bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_nd_decrypt(bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_nd_encrypt(bytea, bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_nd_decrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_ndx_encrypt(bytea, bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_ndx_decrypt(bytea, bigint, bytea)',
+    'pgsodium.crypto_ipcrypt_ndx_encrypt(bytea, bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_ndx_decrypt(bytea, uuid)'
+  ]
+  LOOP
+    EXECUTE pg_catalog.format($i$
+      REVOKE ALL ON FUNCTION %s FROM PUBLIC;
+      GRANT EXECUTE ON FUNCTION %s TO pgsodium_keyiduser;
+    $i$, func, func);
+  END LOOP;
+
+  -- The uuid overloads are SECURITY DEFINER and must be owned by a role that
+  -- can read pgsodium.key (pgsodium_keymaker).
+  FOREACH func IN ARRAY ARRAY[
+    'pgsodium.crypto_ipcrypt_encrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_decrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_pfx_encrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_pfx_decrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_nd_encrypt(bytea, bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_nd_decrypt(bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_ndx_encrypt(bytea, bytea, uuid)',
+    'pgsodium.crypto_ipcrypt_ndx_decrypt(bytea, uuid)'
+  ]
+  LOOP
+    EXECUTE pg_catalog.format('ALTER FUNCTION %s OWNER TO pgsodium_keymaker;', func);
+  END LOOP;
+END
+$$;

--- a/extension/pgsodium--3.1.9--3.1.10.sql
+++ b/extension/pgsodium--3.1.9--3.1.10.sql
@@ -11,9 +11,14 @@ BEGIN
     'GRANT pgsodium_keyiduser, pgsodium_keyholder TO %s',
     masked_role);
 
+  -- view_name may be a schema-qualified name (default 'schema.decrypted_<rel>')
+  -- or a user-supplied 'DECRYPT WITH VIEW' name from a SECURITY LABEL, which is
+  -- untrusted.  Casting to regclass both validates that it resolves to a real
+  -- relation (rejecting injection payloads, which cannot cast) and renders it
+  -- back as a safely-quoted, schema-qualified identifier.
   EXECUTE format(
-    'GRANT ALL ON %I TO %s',
-    view_name,
+    'GRANT ALL ON %s TO %s',
+    view_name::regclass,
     masked_role);
   RETURN;
 END

--- a/pgsodium.control
+++ b/pgsodium.control
@@ -1,5 +1,5 @@
 # pgsodium extension
 comment = 'Postgres extension for libsodium functions'
-default_version = '3.1.9'
+default_version = '3.1.11'
 relocatable = false
 schema = pgsodium

--- a/src/ipcrypt.c
+++ b/src/ipcrypt.c
@@ -1,0 +1,538 @@
+/* doctest/ipcrypt
+-- # IP Address Encryption
+--
+\pset linestyle unicode
+\pset border 2
+\pset pager off
+create extension if not exists pgsodium; -- pragma:hide
+set search_path to pgsodium,public; -- pragma:hide
+--
+-- libsodium (>= 1.0.21) provides the ipcrypt family of functions for
+-- encrypting and anonymizing IP addresses, following the ipcrypt-std
+-- specification (https://ipcrypt-std.github.io).
+--
+-- IP addresses are handled as the 16 byte binary form (IPv4 addresses
+-- are represented as IPv4-mapped IPv6 addresses).  The crypto_ipcrypt_ip2bin()
+-- and crypto_ipcrypt_bin2ip() helpers convert between text and binary forms.
+--
+*/
+
+#include "pgsodium.h"
+
+/* ---------------------------------------------------------------------------
+ * Conversion helpers between text IP addresses and the 16 byte binary form.
+ * ------------------------------------------------------------------------- */
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_ip2bin);
+Datum
+pgsodium_crypto_ipcrypt_ip2bin (PG_FUNCTION_ARGS)
+{
+	text       *ip;
+	char       *ipstr;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ip = PG_GETARG_TEXT_PP (0);
+	ipstr = text_to_cstring (ip);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + 16);
+	ERRORIF (sodium_ip2bin (PGSODIUM_UCHARDATA (result),
+			ipstr, strlen (ipstr)) != 0,
+		"%s: invalid IP address");
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_bin2ip);
+Datum
+pgsodium_crypto_ipcrypt_bin2ip (PG_FUNCTION_ARGS)
+{
+	bytea      *bin;
+	char        ipbuf[64];
+
+	ERRORIF (PG_ARGISNULL (0), "%s: bin cannot be NULL");
+	bin = PG_GETARG_BYTEA_PP (0);
+	ERRORIF (VARSIZE_ANY_EXHDR (bin) != 16, "%s: input must be 16 bytes");
+	ERRORIF (sodium_bin2ip (ipbuf, sizeof (ipbuf),
+			PGSODIUM_UCHARDATA_ANY (bin)) == NULL,
+		"%s: conversion failed");
+	PG_RETURN_TEXT_P (cstring_to_text (ipbuf));
+}
+
+/* ---------------------------------------------------------------------------
+ * Deterministic variant (AES-128, format-preserving).
+ * key 16, input/output 16 bytes.
+ * ------------------------------------------------------------------------- */
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_keygen);
+Datum
+pgsodium_crypto_ipcrypt_keygen (PG_FUNCTION_ARGS)
+{
+	bytea      *result =
+		_pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_KEYBYTES);
+	crypto_ipcrypt_keygen (PGSODIUM_UCHARDATA (result));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_encrypt);
+Datum
+pgsodium_crypto_ipcrypt_encrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key = PG_GETARG_BYTEA_PP (1);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_BYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_BYTES);
+	crypto_ipcrypt_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_decrypt);
+Datum
+pgsodium_crypto_ipcrypt_decrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key = PG_GETARG_BYTEA_PP (1);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_BYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_BYTES);
+	crypto_ipcrypt_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_encrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_encrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key context cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key_id = PG_GETARG_INT64 (1);
+	context = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_BYTES,
+		"%s: invalid input");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_BYTES);
+	crypto_ipcrypt_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_decrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_decrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key context cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key_id = PG_GETARG_INT64 (1);
+	context = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_BYTES,
+		"%s: invalid input");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_BYTES);
+	crypto_ipcrypt_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+/* ---------------------------------------------------------------------------
+ * Prefix-preserving variant (PFX, XOR of two AES-128 permutations).
+ * key 32, input/output 16 bytes.  Preserves network prefix relationships.
+ * ------------------------------------------------------------------------- */
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_pfx_keygen);
+Datum
+pgsodium_crypto_ipcrypt_pfx_keygen (PG_FUNCTION_ARGS)
+{
+	bytea      *result =
+		_pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_PFX_KEYBYTES);
+	crypto_ipcrypt_pfx_keygen (PGSODIUM_UCHARDATA (result));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_pfx_encrypt);
+Datum
+pgsodium_crypto_ipcrypt_pfx_encrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key = PG_GETARG_BYTEA_PP (1);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_PFX_BYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_PFX_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_PFX_BYTES);
+	crypto_ipcrypt_pfx_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_pfx_decrypt);
+Datum
+pgsodium_crypto_ipcrypt_pfx_decrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key = PG_GETARG_BYTEA_PP (1);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_PFX_BYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_PFX_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_PFX_BYTES);
+	crypto_ipcrypt_pfx_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_pfx_encrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_pfx_encrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key context cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key_id = PG_GETARG_INT64 (1);
+	context = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_PFX_BYTES,
+		"%s: invalid input");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_PFX_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_PFX_BYTES);
+	crypto_ipcrypt_pfx_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_pfx_decrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_pfx_decrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key context cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	key_id = PG_GETARG_INT64 (1);
+	context = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_PFX_BYTES,
+		"%s: invalid input");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_PFX_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_PFX_BYTES);
+	crypto_ipcrypt_pfx_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+/* ---------------------------------------------------------------------------
+ * Non-deterministic variant (ND, KIASU-BC).
+ * key 16, tweak 8, input 16, output 24 bytes (tweak prepended).
+ * ------------------------------------------------------------------------- */
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_nd_keygen);
+Datum
+pgsodium_crypto_ipcrypt_nd_keygen (PG_FUNCTION_ARGS)
+{
+	bytea      *result =
+		_pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_ND_KEYBYTES);
+	crypto_ipcrypt_nd_keygen (PGSODIUM_UCHARDATA (result));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_nd_tweakgen);
+Datum
+pgsodium_crypto_ipcrypt_nd_tweakgen (PG_FUNCTION_ARGS)
+{
+	bytea      *result =
+		_pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_ND_TWEAKBYTES);
+	randombytes_buf (VARDATA (result), crypto_ipcrypt_ND_TWEAKBYTES);
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_nd_encrypt);
+Datum
+pgsodium_crypto_ipcrypt_nd_encrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *tweak;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: tweak cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	tweak = PG_GETARG_BYTEA_PP (1);
+	key = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_ND_INPUTBYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (tweak) != crypto_ipcrypt_ND_TWEAKBYTES,
+		"%s: invalid tweak");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_ND_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_ND_OUTPUTBYTES);
+	crypto_ipcrypt_nd_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (tweak),
+		PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_nd_decrypt);
+Datum
+pgsodium_crypto_ipcrypt_nd_decrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ct;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ciphertext cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key cannot be NULL");
+	ct = PG_GETARG_BYTEA_PP (0);
+	key = PG_GETARG_BYTEA_PP (1);
+	ERRORIF (VARSIZE_ANY_EXHDR (ct) != crypto_ipcrypt_ND_OUTPUTBYTES,
+		"%s: invalid ciphertext");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_ND_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_ND_INPUTBYTES);
+	crypto_ipcrypt_nd_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ct), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_nd_encrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_nd_encrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *tweak;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: tweak cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (3), "%s: key context cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	tweak = PG_GETARG_BYTEA_PP (1);
+	key_id = PG_GETARG_INT64 (2);
+	context = PG_GETARG_BYTEA_PP (3);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_ND_INPUTBYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (tweak) != crypto_ipcrypt_ND_TWEAKBYTES,
+		"%s: invalid tweak");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_ND_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_ND_OUTPUTBYTES);
+	crypto_ipcrypt_nd_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (tweak),
+		PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_nd_decrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_nd_decrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ct;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ciphertext cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key context cannot be NULL");
+	ct = PG_GETARG_BYTEA_PP (0);
+	key_id = PG_GETARG_INT64 (1);
+	context = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ct) != crypto_ipcrypt_ND_OUTPUTBYTES,
+		"%s: invalid ciphertext");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_ND_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_ND_INPUTBYTES);
+	crypto_ipcrypt_nd_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ct), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+/* ---------------------------------------------------------------------------
+ * Extended non-deterministic variant (NDX, AES-XTS).
+ * key 32, tweak 16, input 16, output 32 bytes (tweak prepended).
+ * ------------------------------------------------------------------------- */
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_ndx_keygen);
+Datum
+pgsodium_crypto_ipcrypt_ndx_keygen (PG_FUNCTION_ARGS)
+{
+	bytea      *result =
+		_pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_NDX_KEYBYTES);
+	crypto_ipcrypt_ndx_keygen (PGSODIUM_UCHARDATA (result));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_ndx_tweakgen);
+Datum
+pgsodium_crypto_ipcrypt_ndx_tweakgen (PG_FUNCTION_ARGS)
+{
+	bytea      *result =
+		_pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_NDX_TWEAKBYTES);
+	randombytes_buf (VARDATA (result), crypto_ipcrypt_NDX_TWEAKBYTES);
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_ndx_encrypt);
+Datum
+pgsodium_crypto_ipcrypt_ndx_encrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *tweak;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: tweak cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	tweak = PG_GETARG_BYTEA_PP (1);
+	key = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_NDX_INPUTBYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (tweak) != crypto_ipcrypt_NDX_TWEAKBYTES,
+		"%s: invalid tweak");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_NDX_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_NDX_OUTPUTBYTES);
+	crypto_ipcrypt_ndx_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (tweak),
+		PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_ndx_decrypt);
+Datum
+pgsodium_crypto_ipcrypt_ndx_decrypt (PG_FUNCTION_ARGS)
+{
+	bytea      *ct;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ciphertext cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key cannot be NULL");
+	ct = PG_GETARG_BYTEA_PP (0);
+	key = PG_GETARG_BYTEA_PP (1);
+	ERRORIF (VARSIZE_ANY_EXHDR (ct) != crypto_ipcrypt_NDX_OUTPUTBYTES,
+		"%s: invalid ciphertext");
+	ERRORIF (VARSIZE_ANY_EXHDR (key) != crypto_ipcrypt_NDX_KEYBYTES,
+		"%s: invalid key");
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_NDX_INPUTBYTES);
+	crypto_ipcrypt_ndx_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ct), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_ndx_encrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_ndx_encrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ip;
+	bytea      *tweak;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ip cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: tweak cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (3), "%s: key context cannot be NULL");
+	ip = PG_GETARG_BYTEA_PP (0);
+	tweak = PG_GETARG_BYTEA_PP (1);
+	key_id = PG_GETARG_INT64 (2);
+	context = PG_GETARG_BYTEA_PP (3);
+	ERRORIF (VARSIZE_ANY_EXHDR (ip) != crypto_ipcrypt_NDX_INPUTBYTES,
+		"%s: invalid input");
+	ERRORIF (VARSIZE_ANY_EXHDR (tweak) != crypto_ipcrypt_NDX_TWEAKBYTES,
+		"%s: invalid tweak");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_NDX_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_NDX_OUTPUTBYTES);
+	crypto_ipcrypt_ndx_encrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ip), PGSODIUM_UCHARDATA_ANY (tweak),
+		PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}
+
+PG_FUNCTION_INFO_V1 (pgsodium_crypto_ipcrypt_ndx_decrypt_by_id);
+Datum
+pgsodium_crypto_ipcrypt_ndx_decrypt_by_id (PG_FUNCTION_ARGS)
+{
+	bytea      *ct;
+	unsigned long long key_id;
+	bytea      *context;
+	bytea      *key;
+	bytea      *result;
+
+	ERRORIF (PG_ARGISNULL (0), "%s: ciphertext cannot be NULL");
+	ERRORIF (PG_ARGISNULL (1), "%s: key id cannot be NULL");
+	ERRORIF (PG_ARGISNULL (2), "%s: key context cannot be NULL");
+	ct = PG_GETARG_BYTEA_PP (0);
+	key_id = PG_GETARG_INT64 (1);
+	context = PG_GETARG_BYTEA_PP (2);
+	ERRORIF (VARSIZE_ANY_EXHDR (ct) != crypto_ipcrypt_NDX_OUTPUTBYTES,
+		"%s: invalid ciphertext");
+	key = pgsodium_derive_helper (key_id, crypto_ipcrypt_NDX_KEYBYTES, context);
+	result = _pgsodium_zalloc_bytea (VARHDRSZ + crypto_ipcrypt_NDX_INPUTBYTES);
+	crypto_ipcrypt_ndx_decrypt (PGSODIUM_UCHARDATA (result),
+		PGSODIUM_UCHARDATA_ANY (ct), PGSODIUM_UCHARDATA_ANY (key));
+	PG_RETURN_BYTEA_P (result);
+}

--- a/src/pgsodium.h
+++ b/src/pgsodium.h
@@ -265,4 +265,35 @@ PGDLLEXPORT Datum       pgsodium_cmp (PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum       pgsodium_sodium_bin2base64 (PG_FUNCTION_ARGS);
 PGDLLEXPORT Datum       pgsodium_sodium_base642bin (PG_FUNCTION_ARGS);
 
+/* IP Address Encryption (ipcrypt) */
+
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_ip2bin (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_bin2ip (PG_FUNCTION_ARGS);
+
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_keygen (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_encrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_decrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_encrypt_by_id (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_decrypt_by_id (PG_FUNCTION_ARGS);
+
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_pfx_keygen (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_pfx_encrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_pfx_decrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_pfx_encrypt_by_id (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_pfx_decrypt_by_id (PG_FUNCTION_ARGS);
+
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_nd_keygen (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_nd_tweakgen (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_nd_encrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_nd_decrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_nd_encrypt_by_id (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_nd_decrypt_by_id (PG_FUNCTION_ARGS);
+
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_ndx_keygen (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_ndx_tweakgen (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_ndx_encrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_ndx_decrypt (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_ndx_encrypt_by_id (PG_FUNCTION_ARGS);
+PGDLLEXPORT Datum       pgsodium_crypto_ipcrypt_ndx_decrypt_by_id (PG_FUNCTION_ARGS);
+
 #endif /* PGSODIUM_H */

--- a/test/ipcrypt.sql
+++ b/test/ipcrypt.sql
@@ -1,0 +1,201 @@
+-- crypto_ipcrypt_* tests
+--
+-- Known-answer test vectors are taken from the ipcrypt-std reference
+-- implementation (jedisct1/draft-denis-ipcrypt, implementations/python/test_vectors.json).
+
+-- ===========================================================================
+-- Conversion helpers
+-- ===========================================================================
+
+SELECT is(crypto_ipcrypt_bin2ip(crypto_ipcrypt_ip2bin('192.0.2.1')), '192.0.2.1',
+          'ip2bin/bin2ip IPv4 round-trip');
+SELECT is(crypto_ipcrypt_bin2ip(crypto_ipcrypt_ip2bin('2001:db8::1')), '2001:db8::1',
+          'ip2bin/bin2ip IPv6 round-trip');
+SELECT is(octet_length(crypto_ipcrypt_ip2bin('192.0.2.1')), 16, 'ip2bin is 16 bytes');
+SELECT throws_ok($$select crypto_ipcrypt_ip2bin('not-an-ip')$$,
+          '22000', 'pgsodium_crypto_ipcrypt_ip2bin: invalid IP address',
+          'ip2bin rejects garbage');
+SELECT throws_ok($$select crypto_ipcrypt_bin2ip('short'::bytea)$$,
+          '22000', 'pgsodium_crypto_ipcrypt_bin2ip: input must be 16 bytes',
+          'bin2ip rejects wrong size');
+
+-- ===========================================================================
+-- Deterministic variant
+-- ===========================================================================
+
+SELECT crypto_ipcrypt_keygen() detkey \gset
+SELECT is(octet_length(:'detkey'::bytea), 16, 'ipcrypt det keygen is 16 bytes');
+
+-- ipcrypt-std known-answer test (the correctness gate)
+SELECT is(crypto_ipcrypt_encrypt('192.0.2.1'::inet,
+            '\x2b7e151628aed2a6abf7158809cf4f3c'::bytea),
+          '1dbd:c1b9:fff1:7586:7d0b:67b4:e76e:4777'::inet,
+          'ipcrypt det matches ipcrypt-std KAT (192.0.2.1)');
+SELECT is(crypto_ipcrypt_encrypt('0.0.0.0'::inet,
+            '\x0123456789abcdeffedcba9876543210'::bytea),
+          'bde9:6789:d353:824c:d7c6:f58a:6bd2:26eb'::inet,
+          'ipcrypt det matches ipcrypt-std KAT (0.0.0.0)');
+
+-- determinism + round-trip + format preservation (output is 16 bytes)
+SELECT crypto_ipcrypt_ip2bin('203.0.113.5') detip \gset
+SELECT crypto_ipcrypt_encrypt(:'detip'::bytea, :'detkey'::bytea) detct \gset
+SELECT is(crypto_ipcrypt_encrypt(:'detip'::bytea, :'detkey'::bytea), :'detct'::bytea,
+          'ipcrypt det is deterministic');
+SELECT is(crypto_ipcrypt_decrypt(:'detct'::bytea, :'detkey'::bytea), :'detip'::bytea,
+          'ipcrypt det decrypt round-trip');
+SELECT is(octet_length(:'detct'::bytea), 16, 'ipcrypt det output is 16 bytes');
+SELECT is(crypto_ipcrypt_decrypt(crypto_ipcrypt_encrypt('203.0.113.5'::inet, :'detkey'::bytea),
+            :'detkey'::bytea),
+          '203.0.113.5'::inet, 'ipcrypt det inet round-trip');
+
+SELECT throws_ok($$select crypto_ipcrypt_encrypt('\x00000000000000000000000000000000'::bytea, 'short'::bytea)$$,
+          '22000', 'pgsodium_crypto_ipcrypt_encrypt: invalid key',
+          'ipcrypt det rejects bad key size');
+
+-- ===========================================================================
+-- Prefix-preserving variant (PFX)
+-- ===========================================================================
+
+SELECT crypto_ipcrypt_pfx_keygen() pfxkey \gset
+SELECT is(octet_length(:'pfxkey'::bytea), 32, 'ipcrypt pfx keygen is 32 bytes');
+
+-- ipcrypt-std KAT: family-preserving (IPv4 -> IPv4)
+SELECT is(crypto_ipcrypt_pfx_encrypt('192.0.2.1'::inet,
+            '\x0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301'::bytea),
+          '100.115.72.131'::inet,
+          'ipcrypt pfx matches ipcrypt-std KAT (192.0.2.1)');
+
+-- ipcrypt-std KAT: prefix preservation.  Three addresses in 10.0.0.0/24
+-- encrypt to three addresses sharing the prefix 19.214.210.0/24.
+SELECT is(crypto_ipcrypt_pfx_encrypt('10.0.0.47'::inet,
+            '\x2b7e151628aed2a6abf7158809cf4f3ca9f5ba40db214c3798f2e1c23456789a'::bytea),
+          '19.214.210.244'::inet, 'ipcrypt pfx KAT 10.0.0.47');
+SELECT is(crypto_ipcrypt_pfx_encrypt('10.0.0.129'::inet,
+            '\x2b7e151628aed2a6abf7158809cf4f3ca9f5ba40db214c3798f2e1c23456789a'::bytea),
+          '19.214.210.80'::inet, 'ipcrypt pfx KAT 10.0.0.129');
+SELECT is(crypto_ipcrypt_pfx_encrypt('10.0.0.234'::inet,
+            '\x2b7e151628aed2a6abf7158809cf4f3ca9f5ba40db214c3798f2e1c23456789a'::bytea),
+          '19.214.210.30'::inet, 'ipcrypt pfx KAT 10.0.0.234');
+-- the shared /24 prefix is preserved across all three ciphertexts
+SELECT is(count(DISTINCT network(set_masklen(ct, 24)))::int, 1,
+          'ipcrypt pfx preserves the /24 prefix')
+  FROM (VALUES
+    (crypto_ipcrypt_pfx_encrypt('10.0.0.47'::inet,  '\x2b7e151628aed2a6abf7158809cf4f3ca9f5ba40db214c3798f2e1c23456789a'::bytea)),
+    (crypto_ipcrypt_pfx_encrypt('10.0.0.129'::inet, '\x2b7e151628aed2a6abf7158809cf4f3ca9f5ba40db214c3798f2e1c23456789a'::bytea)),
+    (crypto_ipcrypt_pfx_encrypt('10.0.0.234'::inet, '\x2b7e151628aed2a6abf7158809cf4f3ca9f5ba40db214c3798f2e1c23456789a'::bytea))
+  ) AS t(ct);
+
+-- round-trip + bad key
+SELECT is(crypto_ipcrypt_pfx_decrypt(crypto_ipcrypt_pfx_encrypt('198.51.100.23'::inet, :'pfxkey'::bytea),
+            :'pfxkey'::bytea),
+          '198.51.100.23'::inet, 'ipcrypt pfx inet round-trip');
+SELECT throws_ok($$select crypto_ipcrypt_pfx_encrypt('\x00000000000000000000000000000000'::bytea, 'short'::bytea)$$,
+          '22000', 'pgsodium_crypto_ipcrypt_pfx_encrypt: invalid key',
+          'ipcrypt pfx rejects bad key size');
+
+-- ===========================================================================
+-- Non-deterministic variant ND
+-- ===========================================================================
+
+SELECT crypto_ipcrypt_nd_keygen() ndkey \gset
+SELECT is(octet_length(:'ndkey'::bytea), 16, 'ipcrypt nd keygen is 16 bytes');
+SELECT is(octet_length(crypto_ipcrypt_nd_tweakgen()), 8, 'ipcrypt nd tweakgen is 8 bytes');
+
+-- ipcrypt-std KAT (fixed tweak)
+SELECT is(crypto_ipcrypt_nd_encrypt(crypto_ipcrypt_ip2bin('0.0.0.0'),
+            '\x08e0c289bff23b7c'::bytea,
+            '\x0123456789abcdeffedcba9876543210'::bytea),
+          '\x08e0c289bff23b7cb349aadfe3bcef56221c384c7c217b16'::bytea,
+          'ipcrypt nd matches ipcrypt-std KAT');
+
+-- two encryptions with fresh tweaks differ but both decrypt back
+SELECT crypto_ipcrypt_ip2bin('192.0.2.99') ndip \gset
+SELECT crypto_ipcrypt_nd_encrypt(:'ndip'::bytea, crypto_ipcrypt_nd_tweakgen(), :'ndkey'::bytea) ndct1 \gset
+SELECT crypto_ipcrypt_nd_encrypt(:'ndip'::bytea, crypto_ipcrypt_nd_tweakgen(), :'ndkey'::bytea) ndct2 \gset
+SELECT is(octet_length(:'ndct1'::bytea), 24, 'ipcrypt nd output is 24 bytes');
+SELECT isnt(:'ndct1'::bytea, :'ndct2'::bytea, 'ipcrypt nd is non-deterministic across tweaks');
+SELECT is(crypto_ipcrypt_nd_decrypt(:'ndct1'::bytea, :'ndkey'::bytea), :'ndip'::bytea, 'ipcrypt nd decrypt ct1');
+SELECT is(crypto_ipcrypt_nd_decrypt(:'ndct2'::bytea, :'ndkey'::bytea), :'ndip'::bytea, 'ipcrypt nd decrypt ct2');
+
+SELECT throws_ok(format($$select crypto_ipcrypt_nd_encrypt(%L::bytea, 'bad'::bytea, %L::bytea)$$, :'ndip', :'ndkey'),
+          '22000', 'pgsodium_crypto_ipcrypt_nd_encrypt: invalid tweak',
+          'ipcrypt nd rejects bad tweak size');
+
+-- ===========================================================================
+-- Extended non-deterministic variant NDX
+-- ===========================================================================
+
+SELECT crypto_ipcrypt_ndx_keygen() ndxkey \gset
+SELECT is(octet_length(:'ndxkey'::bytea), 32, 'ipcrypt ndx keygen is 32 bytes');
+SELECT is(octet_length(crypto_ipcrypt_ndx_tweakgen()), 16, 'ipcrypt ndx tweakgen is 16 bytes');
+
+-- ipcrypt-std KAT (fixed tweak)
+SELECT is(crypto_ipcrypt_ndx_encrypt(crypto_ipcrypt_ip2bin('0.0.0.0'),
+            '\x21bd1834bc088cd2b4ecbe30b70898d7'::bytea,
+            '\x0123456789abcdeffedcba98765432101032547698badcfeefcdab8967452301'::bytea),
+          '\x21bd1834bc088cd2b4ecbe30b70898d782db0d4125fdace61db35b8339f20ee5'::bytea,
+          'ipcrypt ndx matches ipcrypt-std KAT');
+
+SELECT crypto_ipcrypt_ip2bin('198.51.100.7') ndxip \gset
+SELECT crypto_ipcrypt_ndx_encrypt(:'ndxip'::bytea, crypto_ipcrypt_ndx_tweakgen(), :'ndxkey'::bytea) ndxct1 \gset
+SELECT crypto_ipcrypt_ndx_encrypt(:'ndxip'::bytea, crypto_ipcrypt_ndx_tweakgen(), :'ndxkey'::bytea) ndxct2 \gset
+SELECT is(octet_length(:'ndxct1'::bytea), 32, 'ipcrypt ndx output is 32 bytes');
+SELECT isnt(:'ndxct1'::bytea, :'ndxct2'::bytea, 'ipcrypt ndx is non-deterministic across tweaks');
+SELECT is(crypto_ipcrypt_ndx_decrypt(:'ndxct1'::bytea, :'ndxkey'::bytea), :'ndxip'::bytea, 'ipcrypt ndx decrypt ct1');
+SELECT is(crypto_ipcrypt_ndx_decrypt(:'ndxct2'::bytea, :'ndxkey'::bytea), :'ndxip'::bytea, 'ipcrypt ndx decrypt ct2');
+
+-- ===========================================================================
+-- Server-managed keys (by_id and uuid) -- only when server keys are available
+-- ===========================================================================
+
+\if :serverkeys
+  SET ROLE pgsodium_keyiduser;
+
+  -- deterministic by_id (bigint)
+  SELECT is(crypto_ipcrypt_decrypt(crypto_ipcrypt_encrypt(:'detip'::bytea, 1::bigint), 1::bigint),
+            :'detip'::bytea, 'ipcrypt det by_id round-trip');
+  -- pfx by_id
+  SELECT is(crypto_ipcrypt_pfx_decrypt(crypto_ipcrypt_pfx_encrypt(:'detip'::bytea, 2::bigint), 2::bigint),
+            :'detip'::bytea, 'ipcrypt pfx by_id round-trip');
+  -- nd by_id (tweak supplied)
+  SELECT is(crypto_ipcrypt_nd_decrypt(
+              crypto_ipcrypt_nd_encrypt(:'ndip'::bytea, crypto_ipcrypt_nd_tweakgen(), 3::bigint), 3::bigint),
+            :'ndip'::bytea, 'ipcrypt nd by_id round-trip');
+  -- ndx by_id
+  SELECT is(crypto_ipcrypt_ndx_decrypt(
+              crypto_ipcrypt_ndx_encrypt(:'ndxip'::bytea, crypto_ipcrypt_ndx_tweakgen(), 4::bigint), 4::bigint),
+            :'ndxip'::bytea, 'ipcrypt ndx by_id round-trip');
+
+  RESET ROLE;
+
+  -- uuid-managed keys
+  SELECT id AS det_kid  FROM create_key('ipcrypt-det') \gset
+  SELECT id AS pfx_kid  FROM create_key('ipcrypt-pfx') \gset
+  SELECT id AS nd_kid   FROM create_key('ipcrypt-nd')  \gset
+  SELECT id AS ndx_kid  FROM create_key('ipcrypt-ndx') \gset
+
+  SET ROLE pgsodium_keyiduser;
+
+  SELECT is(crypto_ipcrypt_decrypt(crypto_ipcrypt_encrypt(:'detip'::bytea, :'det_kid'::uuid), :'det_kid'::uuid),
+            :'detip'::bytea, 'ipcrypt det by uuid round-trip');
+  -- deterministic: same input + same key uuid -> same output
+  SELECT is(crypto_ipcrypt_encrypt(:'detip'::bytea, :'det_kid'::uuid),
+            crypto_ipcrypt_encrypt(:'detip'::bytea, :'det_kid'::uuid),
+            'ipcrypt det by uuid is deterministic');
+  SELECT is(crypto_ipcrypt_pfx_decrypt(crypto_ipcrypt_pfx_encrypt(:'detip'::bytea, :'pfx_kid'::uuid), :'pfx_kid'::uuid),
+            :'detip'::bytea, 'ipcrypt pfx by uuid round-trip');
+  SELECT is(crypto_ipcrypt_nd_decrypt(
+              crypto_ipcrypt_nd_encrypt(:'ndip'::bytea, crypto_ipcrypt_nd_tweakgen(), :'nd_kid'::uuid), :'nd_kid'::uuid),
+            :'ndip'::bytea, 'ipcrypt nd by uuid round-trip');
+  SELECT is(crypto_ipcrypt_ndx_decrypt(
+              crypto_ipcrypt_ndx_encrypt(:'ndxip'::bytea, crypto_ipcrypt_ndx_tweakgen(), :'ndx_kid'::uuid), :'ndx_kid'::uuid),
+            :'ndxip'::bytea, 'ipcrypt ndx by uuid round-trip');
+
+  -- inet overload via uuid (format-preserving variants)
+  SELECT is(crypto_ipcrypt_decrypt(crypto_ipcrypt_encrypt('203.0.113.9'::inet, :'det_kid'::uuid), :'det_kid'::uuid),
+            '203.0.113.9'::inet, 'ipcrypt det inet by uuid round-trip');
+  SELECT is(crypto_ipcrypt_pfx_decrypt(crypto_ipcrypt_pfx_encrypt('203.0.113.9'::inet, :'pfx_kid'::uuid), :'pfx_kid'::uuid),
+            '203.0.113.9'::inet, 'ipcrypt pfx inet by uuid round-trip');
+
+  RESET ROLE;
+\endif

--- a/test/pgsodium_schema.sql
+++ b/test/pgsodium_schema.sql
@@ -8,7 +8,7 @@ SELECT cmp_ok(current_setting('server_version_num')::int, '>=', 130000, format('
 
 
 ---- EXTENSION VERSION
-SELECT results_eq('SELECT pgsodium.version()', $$VALUES ('3.1.9'::text)$$, 'Version of pgsodium is 3.1.9');
+SELECT results_eq('SELECT pgsodium.version()', $$VALUES ('3.1.11'::text)$$, 'Version of pgsodium is 3.1.11');
 
 
 ---- EXTENSION OBJECTS
@@ -80,6 +80,46 @@ SELECT bag_eq($$
     ('function pgsodium.crypto_generichash_keygen()'                                                               ::text),
     ('function pgsodium.crypto_hash_sha256(bytea)'                                                                 ::text),
     ('function pgsodium.crypto_hash_sha512(bytea)'                                                                 ::text),
+    ('function pgsodium.crypto_ipcrypt_bin2ip(bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_decrypt(bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_decrypt(bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_decrypt(bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_decrypt(inet,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_decrypt(inet,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_encrypt(bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_encrypt(bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_encrypt(bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_encrypt(inet,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_encrypt(inet,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_ip2bin(text)'::text),
+    ('function pgsodium.crypto_ipcrypt_keygen()'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_decrypt(bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_decrypt(bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_decrypt(bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_encrypt(bytea,bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_encrypt(bytea,bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_encrypt(bytea,bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_keygen()'::text),
+    ('function pgsodium.crypto_ipcrypt_nd_tweakgen()'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_decrypt(bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_decrypt(bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_decrypt(bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_encrypt(bytea,bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_encrypt(bytea,bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_encrypt(bytea,bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_keygen()'::text),
+    ('function pgsodium.crypto_ipcrypt_ndx_tweakgen()'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_decrypt(bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_decrypt(bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_decrypt(bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_decrypt(inet,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_decrypt(inet,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_encrypt(bytea,bigint,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_encrypt(bytea,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_encrypt(bytea,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_encrypt(inet,bytea)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_encrypt(inet,uuid)'::text),
+    ('function pgsodium.crypto_ipcrypt_pfx_keygen()'::text),
     ('function pgsodium.crypto_kdf_derive_from_key(bigint,bigint,bytea,bytea)'                                     ::text),
     ('function pgsodium.crypto_kdf_derive_from_key(integer,bigint,bytea,uuid)'                                     ::text),
     ('function pgsodium.crypto_kdf_keygen()'                                                                       ::text),
@@ -898,6 +938,22 @@ SELECT functions_are('pgsodium', ARRAY[
     'crypto_generichash_keygen',
     'crypto_hash_sha256',
     'crypto_hash_sha512',
+    'crypto_ipcrypt_bin2ip',
+    'crypto_ipcrypt_decrypt',
+    'crypto_ipcrypt_encrypt',
+    'crypto_ipcrypt_ip2bin',
+    'crypto_ipcrypt_keygen',
+    'crypto_ipcrypt_nd_decrypt',
+    'crypto_ipcrypt_nd_encrypt',
+    'crypto_ipcrypt_nd_keygen',
+    'crypto_ipcrypt_nd_tweakgen',
+    'crypto_ipcrypt_ndx_decrypt',
+    'crypto_ipcrypt_ndx_encrypt',
+    'crypto_ipcrypt_ndx_keygen',
+    'crypto_ipcrypt_ndx_tweakgen',
+    'crypto_ipcrypt_pfx_decrypt',
+    'crypto_ipcrypt_pfx_encrypt',
+    'crypto_ipcrypt_pfx_keygen',
     'crypto_kdf_derive_from_key',
     'crypto_kdf_keygen',
     'crypto_kx_client_session_keys',
@@ -5287,7 +5343,7 @@ SELECT function_privs_are('pgsodium'::name, proname, proargtypes::regtype[]::tex
     AND oidvectortypes(proargtypes) = 'oid';
 
 SELECT unnest(ARRAY[
-    is(md5(prosrc), '1b1d814a258347381f8989c6874dc01c',
+    is(md5(prosrc), '2c212e6550b7b586d4b98953fd807f13',
        format('Function pgsodium.%s(%s) body should match checksum',
               proname, pg_get_function_identity_arguments(oid))
     ),
@@ -5819,4 +5875,4 @@ SELECT enums_are('pgsodium', ARRAY[
 ]);
 
 SELECT enum_has_labels('pgsodium','key_status', ARRAY['default','valid','invalid','expired']);
-SELECT enum_has_labels('pgsodium','key_type', ARRAY['aead-ietf','aead-det','hmacsha512','hmacsha256','auth','shorthash','generichash','kdf','secretbox','secretstream','stream_xchacha20']);
+SELECT enum_has_labels('pgsodium','key_type', ARRAY['aead-ietf','aead-det','hmacsha512','hmacsha256','auth','shorthash','generichash','kdf','secretbox','secretstream','stream_xchacha20','ipcrypt-det','ipcrypt-pfx','ipcrypt-nd','ipcrypt-ndx']);

--- a/test/test.sql
+++ b/test/test.sql
@@ -46,6 +46,7 @@ select (current_setting('server_version_num')::int / 10000) = 15 pg15 \gset
 \ir derive.sql
 \ir signcrypt.sql
 \ir helpers.sql
+\ir ipcrypt.sql
 \ir tce.sql
 \ir tce_rls.sql
 \ir keys.sql


### PR DESCRIPTION
## Summary

Implements the libsodium 1.0.22 `crypto_ipcrypt_*` family, exposing the [ipcrypt-std](https://ipcrypt-std.github.io) IP-address encryption/anonymization primitives to SQL, shipped as version **3.1.11**.

Four variants, each following existing pgsodium conventions (bytea C core in `src/ipcrypt.c` + raw-key, `by_id` server-key, and `uuid` managed-key SQL overloads):

| Variant | Prefix | Key | Output | Properties |
| --- | --- | --- | --- | --- |
| Deterministic | `crypto_ipcrypt_` | 16B | 16B | Format-preserving; equal inputs → equal outputs |
| Prefix-preserving | `crypto_ipcrypt_pfx_` | 32B | 16B | Format-preserving + preserves network prefixes |
| Non-deterministic | `crypto_ipcrypt_nd_` | 16B | 24B | Randomized via 8B tweak (KIASU-BC) |
| Extended ND | `crypto_ipcrypt_ndx_` | 32B | 32B | Randomized via 16B tweak (AES-XTS) |

Also adds `crypto_ipcrypt_ip2bin`/`bin2ip` text↔binary helpers, `inet → inet` overloads for the two format-preserving variants, four `ipcrypt-*` key types, and a README section.

## Supporting changes (required to build/test the above)

- **Bump bundled libsodium to 1.0.22** (provides `crypto_ipcrypt`); align debug/example/Windows references.
- **Fix the pending 3.1.10 `mask_role` migration**: `GRANT ALL ON %I` quoted a schema-qualified view name as one identifier, breaking TCE view generation. Now casts `view_name::regclass`, which rejects injection payloads (they can't resolve to a real relation) and renders the qualified name correctly.

## Test Plan

- [x] `./test.sh` — PostgreSQL 14.19 / 15.14 / 16.10 / 17.6 / 18.1 × {no preload, preload, preload+getkey} → **15/15 PASS**
- [x] Tests include official ipcrypt-std known-answer vectors for all four variants, PFX prefix-preservation, ND/NDX non-determinism, and `by_id`/`uuid` round-trips
- [x] Fresh install **and** incremental `3.1.9 → 3.1.11` upgrade verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)