### PR TITLE
Fix use-after-free in pgsodium.getkey_script boot value

### DIFF
--- a/src/pgsodium.c
+++ b/src/pgsodium.c
@@ -108,8 +108,19 @@ _PG_init (void)
 	char       *secret_buf = NULL;
 	size_t      secret_len = 0;
 	size_t      char_read;
-	char       *path;
 	char        sharepath[MAXPGPATH];
+
+	/*
+	 * Buffer holding the default value of pgsodium.getkey_script.
+	 *
+	 * This must have static storage duration.  DefineCustomStringVariable()
+	 * stores the bootValue pointer we hand it as-is, without copying the
+	 * string, and pg_settings dereferences that pointer lazily on every read.
+	 * A palloc'd buffer would be allocated in PostmasterContext, which every
+	 * backend frees during InitPostgres(), so reading boot_val for this GUC
+	 * would then return whatever bytes happened to reuse that freed block.
+	 */
+	static char path[MAXPGPATH];
 
 	if (sodium_init () == -1)
 	{
@@ -135,7 +146,6 @@ _PG_init (void)
 							 NULL, NULL, NULL);
 
     // try to get internal shared key
-	path = (char *) palloc0 (MAXPGPATH);
 	get_share_path (my_exec_path, sharepath);
 	snprintf (path, MAXPGPATH, "%s/extension/%s", sharepath, PG_GETKEY_EXEC);
 

--- a/test/guc.sql
+++ b/test/guc.sql
@@ -1,0 +1,19 @@
+\if :serverkeys
+
+-- The boot value of pgsodium.getkey_script must survive backend startup.
+--
+-- DefineCustomStringVariable() stores the bootValue pointer as-is without
+-- copying the string, and pg_settings dereferences it lazily on every read.
+-- The buffer therefore has to outlive PostmasterContext, which every backend
+-- frees during InitPostgres().  When it does not, boot_val reads freed memory
+-- and returns garbage that varies per backend and may not even be valid in the
+-- database encoding.  See _PG_init() in src/pgsodium.c.
+--
+-- Note this holds regardless of whether pgsodium.getkey_script has been
+-- overridden in the config: boot_val is always the built-in default.
+select is(
+    (select boot_val from pg_settings where name = 'pgsodium.getkey_script'),
+    (select setting from pg_config where name = 'SHAREDIR') || '/extension/pgsodium_getkey',
+    'pgsodium.getkey_script boot_val is the default getkey script path');
+
+\endif

--- a/test/test.sql
+++ b/test/test.sql
@@ -50,6 +50,7 @@ select (current_setting('server_version_num')::int / 10000) = 15 pg15 \gset
 \ir tce.sql
 \ir tce_rls.sql
 \ir keys.sql
+\ir guc.sql
 
 SELECT * FROM finish();
 


### PR DESCRIPTION
Disclaimer: this was analyzed and fixed with Claude Opus. I'm not much
of a Postgres hacker (or C hacker, for that matter), but its analysis and the
fix make sense to me, and I was able to observe the problem reading the
`reset_value` of the setting.

I put the failing test first in its own commit; these should probably be
combined.

---

_PG_init() built the default value for pgsodium.getkey_script in a
palloc0'd buffer and passed it to DefineCustomStringVariable().

DefineCustomStringVariable() stores the bootValue pointer as-is
without copying the string, and retains it for the lifetime of the
process. Because _PG_init() runs from
process_shared_preload_libraries() with PostmasterContext current,
that buffer is allocated in PostmasterContext. This is freed at
backend startup during InitPostgres().

GetConfigOptionValues() dereferences boot_val lazily on each read, so
after backend startup

    SELECT boot_val FROM pg_settings
     WHERE name = 'pgsodium.getkey_script';

reads freed memory and returns whatever bytes have since reused that
block. It also means any user with access to pg_settings can observe
freed heap contents from their own backend.

Note that "setting" and "reset_val" are unaffected:
InitializeOneGUCOption() guc_strdup()s boot_val into GUC memory in the
postmaster, while the buffer is still valid.

Use a static buffer for the boot value so it outlives PostmasterContext.
Static storage also keeps this correct under EXEC_BACKEND, where
_PG_init() runs again in each child.

This was originally introduced in https://github.com/michelp/pgsodium/commit/5c965eab2c3f573420b45e943b5f948d7cf51eaf (v1.3.0-alpha) along with the
GUC itself, then fixed in https://github.com/michelp/pgsodium/commit/f57bd69db9ec691be91b2e6e5350b7c297dbdba7 ("fix for using palloc in init") by
switching to malloc(), which leaves the buffer alive for the life of the
process. It was reintroduced in https://github.com/michelp/pgsodium/commit/06e7ca4a49e24e2e9ed1a916c5877ee17afbd8ee when that malloc() was changed
back to palloc0().